### PR TITLE
hide sqlite3 symbols; (works in linux for now, not tested in Windows/…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 
 # Linker output
 *.ilk
-*.map
 *.exp
 
 # Precompiled Headers

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ SQLITE3_LDFLAGS = $(MY_LDFLAGS)
 LIBDE_SRC_H = $(wildcard src/libdaec/*.h) sqlite3.h
 LIBDE_SRC_C = $(wildcard src/libdaec/*.c)
 LIBDE_SRC_O = $(patsubst %.c,$(CACHEDIR)/%.o,$(notdir $(LIBDE_SRC_C)))
-LIBDE_LDFLAGS = $(MY_LDFLAGS)
+LIBDE_LDFLAGS = $(MY_LDFLAGS) -Wl,--version-script=src/libdaec/symbols.map
 
 LIBDEPROF_SRC_O = $(patsubst %.c,$(PROFDIR)/%.o,$(notdir $(LIBDE_SRC_C)))
 
@@ -164,6 +164,10 @@ lib :
 # redirect generated .o files into .cache
 $(CACHEDIR)/%.o : %.c | $(CACHEDIR)
 	$(COMPILE.c) $(OUTPUT_OPTION) $<
+
+# special rule for sqlite3.c with hidden visibility
+$(CACHEDIR)/sqlite3.o : src/sqlite3/sqlite3.c | $(CACHEDIR)
+	$(COMPILE.c) -fvisibility=hidden $(OUTPUT_OPTION) $<
 
 # redirect generated .o files into .cache
 $(COVDIR)/%.o : %.c | $(COVDIR)

--- a/include/daec.h
+++ b/include/daec.h
@@ -372,7 +372,7 @@ extern "C"
 
     int de_load_ndtseries_axis_ids(de_file de, obj_id_t id, axis_id_t *axis_ids);
 
-    int de_load_ndtseries_value(de_file de, obj_id_t id, void **value);
+    int de_load_ndtseries_value(de_file de, obj_id_t id, const void **value);
 
     int de_load_ndtseries_eltype_elfreq(de_file de, obj_id_t id, type_t *eltype, frequency_t *elfreq);
 

--- a/src/libdaec/axis.c
+++ b/src/libdaec/axis.c
@@ -4,7 +4,7 @@
 #include "axis.h"
 #include "sql.h"
 
-int _get_axis(de_file de, axis_t *axis)
+static int _get_axis(de_file de, axis_t *axis)
 {
     int rc = sql_find_axis(de, axis);
     if (rc == DE_SUCCESS)

--- a/src/libdaec/catalog.c
+++ b/src/libdaec/catalog.c
@@ -12,6 +12,6 @@ int de_new_catalog(de_file de, obj_id_t pid, const char *name, obj_id_t *id)
 {
     if (de == NULL || name == NULL)
         return error(DE_NULL);
-    TRACE_RUN(_new_object(de, pid, class_catalog, type_none, name, id));
+    TRACE_RUN(new_object(de, pid, class_catalog, type_none, name, id));
     return DE_SUCCESS;
 }

--- a/src/libdaec/dates.c
+++ b/src/libdaec/dates.c
@@ -49,7 +49,7 @@ struct __internal_date
     Convert a rata die number to a proleptic Gregorian date.
     Epoch offset given in EPOCH_DAYS
 */
-struct __internal_date _rata_die_to_date(int32_t N_U)
+static struct __internal_date _rata_die_to_date(int32_t N_U)
 {
     /* Figure 12 in https://onlinelibrary.wiley.com/doi/epdf/10.1002/spe.3172 */
 
@@ -87,7 +87,7 @@ struct __internal_date _rata_die_to_date(int32_t N_U)
     Convert a proleptic Gregorian date to its rata die number.
     Epoch offset given in EPOCH_DAYS
 */
-int32_t _date_to_rata_die(struct __internal_date date)
+static int32_t _date_to_rata_die(struct __internal_date date)
 {
     /* Figure 13 in https://onlinelibrary.wiley.com/doi/epdf/10.1002/spe.3172 */
 
@@ -108,7 +108,7 @@ int32_t _date_to_rata_die(struct __internal_date date)
 }
 
 /* weekly frequency; eow = last day of the week mon=1, sun=7 */
-int32_t _rata_die_to_septem(int32_t N_U, uint32_t eow)
+static int32_t _rata_die_to_septem(int32_t N_U, uint32_t eow)
 {
     const uint32_t O_1 = eow % 7;
     const uint32_t O = (O_1 == 0) ? 0 : (7 - O_1);
@@ -120,7 +120,7 @@ int32_t _rata_die_to_septem(int32_t N_U, uint32_t eow)
 
 /* convert day number to business-day number */
 /* weekend, if not NULL, returns 0 - weekday, 1 - Saturday, 2 - Sunday */
-int32_t _rata_die_to_profesto(int32_t N_U, uint32_t *weekend)
+static int32_t _rata_die_to_profesto(int32_t N_U, uint32_t *weekend)
 {
     const uint32_t N = N_U + EPOCH_K + EPOCH_ZERO_DAY;
     const uint32_t N_1 = N - EPOCH_ZERO_MONDAY;
@@ -137,7 +137,7 @@ int32_t _rata_die_to_profesto(int32_t N_U, uint32_t *weekend)
     return Nb_U;
 }
 
-int32_t _rata_die_from_septem(int32_t Nw_U, uint32_t eow)
+static int32_t _rata_die_from_septem(int32_t Nw_U, uint32_t eow)
 {
     const uint32_t O_1 = eow % 7;
     const uint32_t O = (O_1 == 0) ? 0 : (7 - O_1);
@@ -147,7 +147,7 @@ int32_t _rata_die_from_septem(int32_t Nw_U, uint32_t eow)
     return N_U;
 }
 
-int32_t _rata_die_from_profesto(int32_t Nb_U)
+static int32_t _rata_die_from_profesto(int32_t Nb_U)
 {
     const uint32_t Nb = Nb_U + EPOCH_Kb + EPOCH_ZERO_BDAY_SHIFT;
     const uint32_t Nw = Nb / 5;
@@ -162,12 +162,12 @@ int32_t _rata_die_from_profesto(int32_t Nb_U)
 
 static const int YP_FREQS = freq_monthly | freq_quarterly | freq_halfyearly | freq_yearly;
 
-bool _has_ppy(frequency_t freq)
+static bool _has_ppy(frequency_t freq)
 {
     return (freq & YP_FREQS) ? true : false;
 }
 
-int _get_ppy(frequency_t freq, uint32_t *ppy)
+static int _get_ppy(frequency_t freq, uint32_t *ppy)
 {
     switch (freq & YP_FREQS)
     {
@@ -188,7 +188,7 @@ int _get_ppy(frequency_t freq, uint32_t *ppy)
     return error1(DE_INTERNAL, "_get_ppy called on date with non-YP frequency");
 }
 
-int _encode_ppy(frequency_t freq, int32_t year, uint32_t period, int32_t *N)
+static int _encode_ppy(frequency_t freq, int32_t year, uint32_t period, int32_t *N)
 {
     uint32_t ppy = 0;
     TRACE_RUN(_get_ppy(freq, &ppy));
@@ -196,7 +196,7 @@ int _encode_ppy(frequency_t freq, int32_t year, uint32_t period, int32_t *N)
     return DE_SUCCESS;
 }
 
-int _decode_ppy(frequency_t freq, int32_t N_U, int32_t *year, uint32_t *period)
+static int _decode_ppy(frequency_t freq, int32_t N_U, int32_t *year, uint32_t *period)
 {
     uint32_t ppy = 0;
     TRACE_RUN(_get_ppy(freq, &ppy));
@@ -209,7 +209,7 @@ int _decode_ppy(frequency_t freq, int32_t N_U, int32_t *year, uint32_t *period)
 /*****************************************************************************************/
 /* encoding and decoding dates with calendar frequencies */
 
-int _encode_calendar(frequency_t freq, int32_t year, uint32_t month, uint32_t day, int32_t *N)
+static int _encode_calendar(frequency_t freq, int32_t year, uint32_t month, uint32_t day, int32_t *N)
 {
     /* the formulas we use are guaranteed to work for signed 16-bit year */
     /* the formulas work for 0 <= month <= 14 and is known to fail for month = 15 or more.
@@ -238,7 +238,7 @@ int _encode_calendar(frequency_t freq, int32_t year, uint32_t month, uint32_t da
     return error1(DE_INTERNAL, "_encode_calendar called with unsupported frequency");
 }
 
-int _encode_first_period(frequency_t freq, int32_t year, int32_t *N)
+static int _encode_first_period(frequency_t freq, int32_t year, int32_t *N)
 {
     int rc = _encode_calendar(freq, year, 1, 1, N);
     if (rc == DE_INEXACT)
@@ -247,10 +247,14 @@ int _encode_first_period(frequency_t freq, int32_t year, int32_t *N)
         *N = *N + 1;
         rc = de_clear_error();
     }
+    else
+    {
+        TRACE_RUN(rc);
+    }
     return rc;
 }
 
-int _decode_calendar(frequency_t freq, int32_t N, int32_t *year, uint32_t *month, uint32_t *day)
+static int _decode_calendar(frequency_t freq, int32_t N, int32_t *year, uint32_t *month, uint32_t *day)
 {
     if (freq == freq_daily)
     {
@@ -349,7 +353,7 @@ int de_pack_calendar_date(frequency_t freq, int32_t year, uint32_t month, uint32
     return DE_SUCCESS;
 }
 
-uint32_t _days_in_month(int32_t Y, uint32_t M)
+static uint32_t _days_in_month(int32_t Y, uint32_t M)
 {
     if (M == 2)
         return 28 + (Y % 4 == 0) - (Y % 100 == 0) + (Y % 400 == 0);
@@ -369,8 +373,8 @@ int de_unpack_calendar_date(frequency_t freq, date_t date, int32_t *year, uint32
         TRACE_RUN(_get_ppy(freq, &ppy));
         if (ppy > 12)
             return error1(DE_INTERNAL, "ppy > 12 not supported in de_unpack_calendar_date");
-        uint32_t P;
-        int32_t Y;
+        uint32_t P = 0;
+        int32_t Y = 0;
         TRACE_RUN(_decode_ppy(freq, N, &Y, &P));
         const uint32_t X = freq % 16; /* end month of period in frequency*/
         const uint32_t M = (P - (X > 0)) * 12 / ppy + X;

--- a/src/libdaec/error.c
+++ b/src/libdaec/error.c
@@ -39,7 +39,7 @@ int de_clear_error(void)
     return DE_SUCCESS;
 }
 
-void _push_trace(const char *func, const char *file, int line)
+static void _push_trace(const char *func, const char *file, int line)
 {
     char *trace = last_error.source_trace;
     int len = strlen(trace);

--- a/src/libdaec/file.c
+++ b/src/libdaec/file.c
@@ -16,7 +16,7 @@
     if (SQLITE_OK != sqlite3_exec((de)->db, (sql), NULL, NULL, NULL)) \
         return db_error(de);
 
-int _init_file(de_file de)
+static int _init_file(de_file de)
 {
     /* make tables */
     RUN_SQL(de,
@@ -122,7 +122,7 @@ int _init_file(de_file de)
     return DE_SUCCESS;
 }
 
-const char *_get_statement_sql(stmt_name_t stmt_name)
+static const char *_get_sql_text(stmt_name_t stmt_name)
 {
     switch (stmt_name)
     {
@@ -194,7 +194,7 @@ const char *_get_statement_sql(stmt_name_t stmt_name)
     }
 }
 
-sqlite3_stmt *_get_statement(de_file de, stmt_name_t stmt_name)
+sqlite3_stmt *sql_statement(de_file de, stmt_name_t stmt_name)
 {
     if ((stmt_name < 0) || (stmt_size <= stmt_name))
     {
@@ -204,7 +204,7 @@ sqlite3_stmt *_get_statement(de_file de, stmt_name_t stmt_name)
     sqlite3_stmt *stmt = de->stmt[stmt_name];
     if (stmt != NULL)
         return stmt;
-    const char *sql = _get_statement_sql(stmt_name);
+    const char *sql = _get_sql_text(stmt_name);
     if (sql == NULL)
     {
         trace_error();
@@ -219,7 +219,17 @@ sqlite3_stmt *_get_statement(de_file de, stmt_name_t stmt_name)
     return stmt;
 }
 
-int _open(const char *fname, de_file *pde, int flags)
+/* check if a file exists at the given path */
+static bool _isfile(const char *path)
+{
+    FILE *f = fopen(path, "r");
+    if (f == NULL)
+        return false;
+    fclose(f);
+    return true;
+}
+
+static int _open(const char *fname, de_file *pde, int flags)
 {
 
     if (pde == NULL)
@@ -305,7 +315,7 @@ int de_begin_transaction(de_file de)
     return DE_SUCCESS;
 }
 
-int _fin_stmts(de_file de)
+static int _fin_stmts(de_file de)
 {
     for (stmt_name_t i = 0; i < stmt_last; ++i)
     {

--- a/src/libdaec/file.h
+++ b/src/libdaec/file.h
@@ -71,14 +71,8 @@ struct de_file_s
     bool transaction;
 };
 
-/* called when creating a new de_file. creates tables and indexes */
-int _init_file(de_file de);
-
-/* return a static buffer containing the SQL text for the given stmt_name */
-const char *_get_statement_sql(stmt_name_t stmt_name);
-
 /* return a prepared statement by the given name */
-sqlite3_stmt *_get_statement(de_file de, stmt_name_t stmt_name);
+sqlite3_stmt *sql_statement(de_file de, stmt_name_t stmt_name);
 
 /* functions that start and post transactions */
 int de_commit(de_file de);

--- a/src/libdaec/misc.c
+++ b/src/libdaec/misc.c
@@ -14,34 +14,11 @@ const char *de_version(void)
     return DE_VERSION;
 }
 
-const int de_max_axes(void)
+int de_max_axes(void)
 {
     return DE_MAX_AXES;
 }
 
-/* check if a file exists at the given path */
-bool _isfile(const char *path)
-{
-    FILE *f = fopen(path, "r");
-    if (f == NULL)
-        return false;
-    fclose(f);
-    return true;
-}
-
-const char *_id2str(int64_t id)
-{
-    static char buffer[100];
-    snprintf(buffer, 100, "id=%" PRId64, id);
-    return buffer;
-}
-
-const char *_pidnm2str(int64_t pid, const char *name)
-{
-    static char buffer[100];
-    snprintf(buffer, 100, "pid=%" PRId64 ",name='%s'", pid, name);
-    return buffer;
-}
 
 /*
     pack a vector of strings into a contiguous memory buffer.

--- a/src/libdaec/misc.h
+++ b/src/libdaec/misc.h
@@ -13,7 +13,7 @@
 const char *de_version(void);
 
 /* returns the current setting for DE_MAX_AXES*/
-const int de_max_axes(void);
+int de_max_axes(void);
 
 /*
     pack a vector of strings into a contiguous memory buffer.
@@ -51,14 +51,5 @@ int de_unpack_strings(const char *buffer, int64_t bufsize, const char **strvec, 
 
 /* ========================================================================= */
 /* internal */
-
-/* check if the given path is a file that can be opened for reading */
-bool _isfile(const char *path);
-
-/* make a string "id=N" given integer N */
-const char *_id2str(int64_t id);
-
-/* make a string "pid=N,name='abc'" given integer N */
-const char *_pidnm2str(int64_t pid, const char *name);
 
 #endif

--- a/src/libdaec/mvtseries.c
+++ b/src/libdaec/mvtseries.c
@@ -26,7 +26,7 @@ int de_store_mvtseries(de_file de, obj_id_t pid, const char *name, type_t obj_ty
     TRACE_RUN(validate_eltype(obj_type, eltype, elfreq));
 
     obj_id_t _id;
-    TRACE_RUN(_new_object(de, pid, class_mvtseries, obj_type, name, &_id));
+    TRACE_RUN(new_object(de, pid, class_mvtseries, obj_type, name, &_id));
     if (id != NULL)
         *id = _id;
     TRACE_RUN(sql_store_mvtseries_value(de, _id, eltype, elfreq, axis1_id, axis2_id, nbytes, value));

--- a/src/libdaec/ndtseries.c
+++ b/src/libdaec/ndtseries.c
@@ -29,7 +29,7 @@ int de_store_ndtseries(de_file de, obj_id_t pid, const char *name, type_t obj_ty
         return error(DE_BAD_NUM_AXES);
 
     obj_id_t _id;
-    TRACE_RUN(_new_object(de, pid, class_ndtseries, obj_type, name, &_id));
+    TRACE_RUN(new_object(de, pid, class_ndtseries, obj_type, name, &_id));
     if (id != NULL)
         *id = _id;
     TRACE_RUN(sql_store_ndtseries_value(de, _id, eltype, elfreq, nbytes, value));
@@ -68,7 +68,7 @@ int de_load_ndtseries_eltype_elfreq(de_file de, obj_id_t id, type_t *eltype, fre
     return DE_SUCCESS;
 }
 
-int de_load_ndtseries_value(de_file de, obj_id_t id, void **value)
+int de_load_ndtseries_value(de_file de, obj_id_t id, const void **value)
 {
     if (de == NULL)
         return error(DE_NULL);

--- a/src/libdaec/ndtseries.h
+++ b/src/libdaec/ndtseries.h
@@ -35,7 +35,7 @@ int de_load_ndtseries(de_file de, obj_id_t id, ndtseries_t *ndtseries);
 
 int de_load_ndtseries_axis_ids(de_file de, obj_id_t id, axis_id_t *axis_ids);
 
-int de_load_ndtseries_value(de_file de, obj_id_t id, void **value);
+int de_load_ndtseries_value(de_file de, obj_id_t id, const void **value);
 
 int de_load_ndtseries_eltype_elfreq(de_file de, obj_id_t id, type_t *eltype, frequency_t *elfreq);
 

--- a/src/libdaec/object.c
+++ b/src/libdaec/object.c
@@ -11,7 +11,7 @@
 #include "sql.h"
 
 /* check if the given string is a valid object name */
-bool _check_name(const char *name)
+static bool _check_name(const char *name)
 {
     /* check that name is not empty */
     if (*name == '\0')
@@ -40,7 +40,7 @@ bool _check_name(const char *name)
     return true;
 }
 
-int _new_object(de_file de, obj_id_t pid, class_t class, type_t type, const char *name, obj_id_t *id)
+int new_object(de_file de, obj_id_t pid, class_t class, type_t type, const char *name, obj_id_t *id)
 {
     if (!_check_name(name))
         return trace_error();

--- a/src/libdaec/object.h
+++ b/src/libdaec/object.h
@@ -102,11 +102,8 @@ int de_catalog_size(de_file de, obj_id_t pid, int64_t *count);
 /* ========================================================================= */
 /* internal */
 
-int _new_object(de_file de, obj_id_t pid, class_t class, type_t type,
+int new_object(de_file de, obj_id_t pid, class_t class, type_t type,
                 const char *name, obj_id_t *id);
-
-/* check if the given string is a valid object name */
-bool _check_name(const char *name);
 
 bool check_scalar_type(type_t type);
 bool check_tseries_type(type_t type);

--- a/src/libdaec/scalar.c
+++ b/src/libdaec/scalar.c
@@ -26,7 +26,7 @@ int de_store_scalar(de_file de, obj_id_t pid, const char *name, type_t type,
     if (!check_scalar_type(type))
         return error(DE_BAD_TYPE);
     obj_id_t _id;
-    TRACE_RUN(_new_object(de, pid, class_scalar, type, name, &_id));
+    TRACE_RUN(new_object(de, pid, class_scalar, type, name, &_id));
     if (id != NULL)
         *id = _id;
     TRACE_RUN(sql_store_scalar_value(de, _id, freq, nbytes, value));

--- a/src/libdaec/search.c
+++ b/src/libdaec/search.c
@@ -25,7 +25,7 @@ static char *_push_string(char *p, const char *str)
     return p;
 }
 
-int _prepare_search(de_file de, int64_t pid, const char *wc, type_t type, class_t class, search_t *search)
+static int _prepare_search(de_file de, int64_t pid, const char *wc, type_t type, class_t class, search_t *search)
 {
     enum
     {
@@ -128,7 +128,7 @@ int de_next_object(de_search search, object_t *object)
     switch (rc)
     {
     case SQLITE_ROW:
-        _fill_object(search->stmt, object);
+        sql_fill_object(search->stmt, object);
         return DE_SUCCESS;
     case SQLITE_DONE:
         sqlite3_finalize(search->stmt);

--- a/src/libdaec/sql.c
+++ b/src/libdaec/sql.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <inttypes.h>
 
 #include "config.h"
 #include "error.h"
@@ -24,9 +25,27 @@
             return rc_error(rc);          \
     }
 
+/* helper functions for formatting error messages */
+    
+static const char *_id2str(int64_t id)
+{
+    static char buffer[100];
+    snprintf(buffer, 100, "id=%" PRId64, id);
+    return buffer;
+}
+
+static const char *_pidnm2str(int64_t pid, const char *name)
+{
+    static char buffer[100];
+    snprintf(buffer, 100, "pid=%" PRId64 ",name='%s'", pid, name);
+    return buffer;
+}
+
+/* ************************************************************************* */
+
 int sql_find_object(de_file de, obj_id_t pid, const char *name, obj_id_t *id)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_find_object);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_find_object);
     if (stmt == NULL)
         return trace_error();
     int rc;
@@ -46,7 +65,7 @@ int sql_find_object(de_file de, obj_id_t pid, const char *name, obj_id_t *id)
     }
 }
 
-void _fill_object(sqlite3_stmt *stmt, object_t *object)
+void sql_fill_object(sqlite3_stmt *stmt, object_t *object)
 {
     object->id = sqlite3_column_int64(stmt, 0);
     object->pid = sqlite3_column_int64(stmt, 1);
@@ -57,7 +76,7 @@ void _fill_object(sqlite3_stmt *stmt, object_t *object)
 
 int sql_load_object(de_file de, obj_id_t id, object_t *object)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_load_object);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_load_object);
     if (stmt == NULL)
         return trace_error();
     int rc;
@@ -66,7 +85,7 @@ int sql_load_object(de_file de, obj_id_t id, object_t *object)
     switch ((rc = sqlite3_step(stmt)))
     {
     case SQLITE_ROW:
-        _fill_object(stmt, object);
+        sql_fill_object(stmt, object);
         return DE_SUCCESS;
     case SQLITE_DONE:
         return error1(DE_OBJ_DNE, _id2str(id));
@@ -78,7 +97,7 @@ int sql_load_object(de_file de, obj_id_t id, object_t *object)
 
 int sql_new_object(de_file de, obj_id_t pid, class_t class, type_t type, const char *name)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_new_object);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_new_object);
     if (stmt == NULL)
         return trace_error();
     int rc;
@@ -93,7 +112,7 @@ int sql_new_object(de_file de, obj_id_t pid, class_t class, type_t type, const c
 
 int sql_new_object_info(de_file de, obj_id_t id)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_new_object_info);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_new_object_info);
     if (stmt == NULL)
         return trace_error();
     int rc;
@@ -105,7 +124,7 @@ int sql_new_object_info(de_file de, obj_id_t id)
 
 int sql_delete_object(de_file de, obj_id_t id)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_delete_object);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_delete_object);
     if (stmt == NULL)
         return trace_error();
     if (id == 0)
@@ -119,7 +138,7 @@ int sql_delete_object(de_file de, obj_id_t id)
 
 int sql_set_attribute(de_file de, int64_t id, const char *name, const char *value)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_set_attribute);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_set_attribute);
     if (stmt == NULL)
         return trace_error();
     int rc;
@@ -140,7 +159,7 @@ int sql_set_attribute(de_file de, int64_t id, const char *name, const char *valu
 
 int sql_get_attribute(de_file de, int64_t id, const char *name, const char **value)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_get_attribute);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_get_attribute);
     if (stmt == NULL)
         return trace_error();
     int rc;
@@ -163,7 +182,7 @@ int sql_get_attribute(de_file de, int64_t id, const char *name, const char **val
 int sql_get_all_attributes(de_file de, obj_id_t id, const char *delim,
                            int64_t *nattr, const char **names, const char **values)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_get_all_attributes);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_get_all_attributes);
     if (stmt == NULL)
         return trace_error();
     int rc;
@@ -191,7 +210,7 @@ int sql_get_all_attributes(de_file de, obj_id_t id, const char *delim,
 
 int sql_get_object_info(de_file de, obj_id_t id, const char **fullpath, int64_t *depth, int64_t *created)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_get_object_info);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_get_object_info);
     if (stmt == NULL)
         return trace_error();
     int rc;
@@ -216,7 +235,7 @@ int sql_get_object_info(de_file de, obj_id_t id, const char **fullpath, int64_t 
 
 int sql_find_fullpath(de_file de, const char *fullpath, obj_id_t *id)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_find_fullpath);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_find_fullpath);
     if (stmt == NULL)
         return trace_error();
     int rc;
@@ -236,7 +255,7 @@ int sql_find_fullpath(de_file de, const char *fullpath, obj_id_t *id)
 
 int sql_store_scalar_value(de_file de, obj_id_t id, frequency_t frequency, int64_t nbytes, const void *value)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_store_scalar);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_store_scalar);
     if (stmt == NULL)
         return trace_error();
     int rc;
@@ -255,7 +274,7 @@ int sql_store_scalar_value(de_file de, obj_id_t id, frequency_t frequency, int64
     return rc == SQLITE_DONE ? DE_SUCCESS : rc_error(rc);
 }
 
-void _fill_scalar(sqlite3_stmt *stmt, scalar_t *scalar)
+static void _fill_scalar(sqlite3_stmt *stmt, scalar_t *scalar)
 {
     obj_id_t id = sqlite3_column_int64(stmt, 0);
     if (id != scalar->object.id)
@@ -267,7 +286,7 @@ void _fill_scalar(sqlite3_stmt *stmt, scalar_t *scalar)
 
 int sql_load_scalar_value(de_file de, obj_id_t id, scalar_t *scalar)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_load_scalar);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_load_scalar);
     if (stmt == NULL)
         return trace_error();
     int rc;
@@ -289,7 +308,7 @@ int sql_load_scalar_value(de_file de, obj_id_t id, scalar_t *scalar)
 /******************************************************************/
 /* axis */
 
-int _fill_axis(sqlite3_stmt *stmt, axis_t *axis)
+static int _fill_axis(sqlite3_stmt *stmt, axis_t *axis)
 {
     axis->id = sqlite3_column_int64(stmt, 0);
     axis->ax_type = sqlite3_column_int(stmt, 1);
@@ -317,7 +336,7 @@ int _fill_axis(sqlite3_stmt *stmt, axis_t *axis)
 
 int sql_load_axis(de_file de, axis_id_t id, axis_t *axis)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_load_axis);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_load_axis);
     if (stmt == NULL)
         return trace_error();
     int rc;
@@ -337,7 +356,7 @@ int sql_load_axis(de_file de, axis_id_t id, axis_t *axis)
 
 int sql_find_axis(de_file de, axis_t *axis)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_find_axis);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_find_axis);
     if (stmt == NULL)
         return trace_error();
     int rc;
@@ -383,7 +402,7 @@ int sql_find_axis(de_file de, axis_t *axis)
 
 int sql_new_axis(de_file de, axis_t *axis)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_new_axis);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_new_axis);
     if (stmt == NULL)
         return trace_error();
     int rc;
@@ -422,7 +441,7 @@ int sql_store_tseries_value(de_file de, obj_id_t id,
                             axis_id_t axis_id, int64_t nbytes,
                             const void *value)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_store_tseries);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_store_tseries);
     if (stmt == NULL)
         return trace_error();
     int rc;
@@ -443,7 +462,7 @@ int sql_store_tseries_value(de_file de, obj_id_t id,
     return rc == SQLITE_DONE ? DE_SUCCESS : rc_error(rc);
 }
 
-void _fill_tseries(sqlite3_stmt *stmt, tseries_t *tseries)
+static void _fill_tseries(sqlite3_stmt *stmt, tseries_t *tseries)
 {
     obj_id_t id = sqlite3_column_int64(stmt, 0);
     if (id != tseries->object.id)
@@ -457,7 +476,7 @@ void _fill_tseries(sqlite3_stmt *stmt, tseries_t *tseries)
 
 int sql_load_tseries_value(de_file de, obj_id_t id, tseries_t *tseries)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_load_tseries);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_load_tseries);
     if (stmt == NULL)
         return trace_error();
     int rc;
@@ -484,7 +503,7 @@ int sql_store_mvtseries_value(de_file de, obj_id_t id,
                               axis_id_t axis1_id, axis_id_t axis2_id,
                               int64_t nbytes, const void *value)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_store_mvtseries);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_store_mvtseries);
     if (stmt == NULL)
         return trace_error();
     int rc;
@@ -506,7 +525,7 @@ int sql_store_mvtseries_value(de_file de, obj_id_t id,
     return rc == SQLITE_DONE ? DE_SUCCESS : rc_error(rc);
 }
 
-void _fill_mvtseries(sqlite3_stmt *stmt, mvtseries_t *mvtseries)
+static void _fill_mvtseries(sqlite3_stmt *stmt, mvtseries_t *mvtseries)
 {
     obj_id_t id = sqlite3_column_int64(stmt, 0);
     if (id != mvtseries->object.id)
@@ -521,7 +540,7 @@ void _fill_mvtseries(sqlite3_stmt *stmt, mvtseries_t *mvtseries)
 
 int sql_load_mvtseries_value(de_file de, obj_id_t id, mvtseries_t *mvtseries)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_load_mvtseries);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_load_mvtseries);
     if (stmt == NULL)
         return trace_error();
     int rc;
@@ -547,7 +566,7 @@ int sql_load_mvtseries_value(de_file de, obj_id_t id, mvtseries_t *mvtseries)
 int sql_store_ndtseries_value(de_file de, obj_id_t id, type_t eltype, frequency_t elfreq,
                               int64_t nbytes, const void *value)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_store_ndtseries);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_store_ndtseries);
     if (stmt == NULL)
         return trace_error();
     int rc;
@@ -569,7 +588,7 @@ int sql_store_ndtseries_value(de_file de, obj_id_t id, type_t eltype, frequency_
 
 int sql_store_ndaxes(de_file de, obj_id_t obj_id, int64_t axis_index, axis_id_t axis_id)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_store_ndaxes);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_store_ndaxes);
     if (stmt == NULL)
         return trace_error();
     int rc;
@@ -581,7 +600,7 @@ int sql_store_ndaxes(de_file de, obj_id_t obj_id, int64_t axis_index, axis_id_t 
     return rc == SQLITE_DONE ? DE_SUCCESS : rc_error(rc);
 }
 
-void _fill_ndtseries(sqlite3_stmt *stmt, ndtseries_t *ndtseries)
+static void _fill_ndtseries(sqlite3_stmt *stmt, ndtseries_t *ndtseries)
 {
     obj_id_t id = sqlite3_column_int64(stmt, 0);
     if (id != ndtseries->object.id)
@@ -592,9 +611,9 @@ void _fill_ndtseries(sqlite3_stmt *stmt, ndtseries_t *ndtseries)
     ndtseries->value = sqlite3_column_blob(stmt, 3);
 }
 
-int _sql_load_ndaxes(de_file de, ndtseries_t *ndtseries)
+static int _sql_load_ndaxes(de_file de, ndtseries_t *ndtseries)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_load_ndaxes);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_load_ndaxes);
     if (stmt == NULL)
         return trace_error();
     int rc;
@@ -630,7 +649,7 @@ int _sql_load_ndaxes(de_file de, ndtseries_t *ndtseries)
 
 int sql_load_ndaxes_ids(de_file de, obj_id_t obj_id, axis_id_t *axes_ids)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_load_ndaxes_ids);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_load_ndaxes_ids);
     if (stmt == NULL)
         return trace_error();
     int rc;
@@ -662,7 +681,7 @@ int sql_load_ndaxes_ids(de_file de, obj_id_t obj_id, axis_id_t *axes_ids)
 
 int sql_load_ndtseries_value(de_file de, obj_id_t id, ndtseries_t *ndtseries)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_load_ndtseries);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_load_ndtseries);
     if (stmt == NULL)
         return trace_error();
     int rc;
@@ -681,9 +700,9 @@ int sql_load_ndtseries_value(de_file de, obj_id_t id, ndtseries_t *ndtseries)
     }
 }
 
-int sql_load_ndtseries_value_field(de_file de, obj_id_t id, void **value)
+int sql_load_ndtseries_value_field(de_file de, obj_id_t id, const void **value)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_load_ndtseries_value);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_load_ndtseries_value);
     if (stmt == NULL)
         return trace_error();
     int rc;
@@ -703,7 +722,7 @@ int sql_load_ndtseries_value_field(de_file de, obj_id_t id, void **value)
 
 int sql_load_ndtseries_eltype_elfreq(de_file de, obj_id_t id, type_t *eltype, frequency_t *elfreq)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_load_ndtseries_eltype_elfreq);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_load_ndtseries_eltype_elfreq);
     if (stmt == NULL)
         return trace_error();
     int rc;
@@ -728,7 +747,7 @@ int sql_load_ndtseries_eltype_elfreq(de_file de, obj_id_t id, type_t *eltype, fr
 
 int sql_count_objects(de_file de, obj_id_t pid, int64_t *count)
 {
-    sqlite3_stmt *stmt = _get_statement(de, stmt_count_objects);
+    sqlite3_stmt *stmt = sql_statement(de, stmt_count_objects);
     if (stmt == NULL)
         return trace_error();
     int rc;

--- a/src/libdaec/sql.h
+++ b/src/libdaec/sql.h
@@ -14,7 +14,7 @@
 /* ========================================================================= */
 /* internal */
 
-void _fill_object(sqlite3_stmt *stmt, object_t *object);
+void sql_fill_object(sqlite3_stmt *stmt, object_t *object);
 
 /* find the id of an object identified by its parent and its name */
 int sql_find_object(de_file de, obj_id_t pid, const char *name, obj_id_t *id);
@@ -88,7 +88,7 @@ int sql_load_ndtseries_value(de_file de, obj_id_t id, ndtseries_t *ndmvtseries);
 int sql_load_ndaxes_ids(de_file de, obj_id_t obj_id, axis_id_t *axes_ids);
 
 /* load an the value field of the ndtseries table with the given id */
-int sql_load_ndtseries_value_field(de_file de, obj_id_t id, void **value);
+int sql_load_ndtseries_value_field(de_file de, obj_id_t id, const void **value);
 
 /* load an the eltype and elfreq fields of the ndtseries table with the given id */
 int sql_load_ndtseries_eltype_elfreq(de_file de, obj_id_t id, type_t *eltype, frequency_t *elfreq);

--- a/src/libdaec/symbols.map
+++ b/src/libdaec/symbols.map
@@ -1,0 +1,7 @@
+{
+    global:
+        de_*;
+        get_*_from_voidptr*;
+    local:
+        *;
+};

--- a/src/libdaec/tseries.c
+++ b/src/libdaec/tseries.c
@@ -34,7 +34,7 @@ int de_store_tseries(de_file de, obj_id_t pid, const char *name, type_t obj_type
         return error(DE_BAD_TYPE);
     TRACE_RUN(validate_eltype(obj_type, eltype, elfreq));
     obj_id_t _id;
-    TRACE_RUN(_new_object(de, pid, class_tseries, obj_type, name, &_id));
+    TRACE_RUN(new_object(de, pid, class_tseries, obj_type, name, &_id));
     if (id != NULL)
         *id = _id;
     TRACE_RUN(sql_store_tseries_value(de, _id, eltype, elfreq, axis_id, nbytes, value));


### PR DESCRIPTION
…MacOS)

also marked local functions as `static` so compiler can optimize better

also moved some things around